### PR TITLE
add toml encode and decode

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,7 +64,7 @@ func (g *goConfig) Parse() error {
 	}
 	g.flags = f
 	if g.fileEnabled {
-		g.genConfig = flag.String("g", "", "generate config file (toml,json,yaml)")
+		g.genConfig = flag.String("g", "", "generate config file (toml,json,yaml,env)")
 		flag.StringVar(g.genConfig, "gen", "", "")
 		g.configPath = flag.String("c", "", "path for config file")
 		flag.StringVar(g.configPath, "config", "", "")

--- a/encoding/file/decode.go
+++ b/encoding/file/decode.go
@@ -22,7 +22,7 @@ func Load(f string, i interface{}) error {
 			return err
 		}
 		return json.Unmarshal(b, i)
-	case "yaml":
+	case "yaml", "yml":
 		b, err := ioutil.ReadFile(f)
 		if err != nil {
 			return err

--- a/encoding/file/decode.go
+++ b/encoding/file/decode.go
@@ -1,0 +1,34 @@
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/hydronica/toml"
+	"gopkg.in/yaml.v2"
+)
+
+// Load config from file, type is determined by the file extension
+func Load(f string, i interface{}) error {
+	switch filepath.Ext(f) {
+	case "toml":
+		_, err := toml.DecodeFile(f, i)
+		return err
+	case "json":
+		b, err := ioutil.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(b, i)
+	case "yaml":
+		b, err := ioutil.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		return yaml.Unmarshal(b, i)
+	default:
+		return fmt.Errorf("unknown file type %s", filepath.Ext(f))
+	}
+}

--- a/encoding/file/encode.go
+++ b/encoding/file/encode.go
@@ -1,0 +1,37 @@
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/hydronica/toml"
+	"gopkg.in/yaml.v2"
+)
+
+// Encode a config to a file based on the ext passed in
+// Note: only toml supports comments
+func Encode(w io.Writer, i interface{}, ext string) error {
+	switch ext {
+	case "toml":
+		enc := toml.NewEncoder(w)
+		return enc.Encode(i)
+	case "yaml":
+		b, err := yaml.Marshal(i)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	case "json":
+		b, err := json.MarshalIndent(i, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	default:
+		return fmt.Errorf("unsupported config extension %s", ext)
+	}
+	return nil
+}

--- a/encoding/file/encode.go
+++ b/encoding/file/encode.go
@@ -33,5 +33,4 @@ func Encode(w io.Writer, i interface{}, ext string) error {
 	default:
 		return fmt.Errorf("unsupported config extension %s", ext)
 	}
-	return nil
 }

--- a/encoding/file/encode.go
+++ b/encoding/file/encode.go
@@ -16,7 +16,7 @@ func Encode(w io.Writer, i interface{}, ext string) error {
 	case "toml":
 		enc := toml.NewEncoder(w)
 		return enc.Encode(i)
-	case "yaml":
+	case "yaml", "yml":
 		b, err := yaml.Marshal(i)
 		if err != nil {
 			return err

--- a/encoding/flag/flag.go
+++ b/encoding/flag/flag.go
@@ -89,7 +89,6 @@ func New(i interface{}) (*Flags, error) {
 			goto switchStart // easiest solution, but do we want a goto statement
 		case reflect.Struct:
 			// todo: Should we add a prefix for flags? structName-childVar or only
-			// support a struct if they implement a marshaler
 			if field.Type().String() == "time.Time" {
 				timeFmt := dField.Tag.Get(fmtTag)
 				timeFmt = getTimeFormat(timeFmt)
@@ -97,6 +96,7 @@ func New(i interface{}) (*Flags, error) {
 				flagSet.String(tag, t.Format(timeFmt), desc)
 				continue
 			}
+			// support a struct if they implement a marshaler
 			if implementsMarshaler(field) {
 				b, _ := field.Interface().(encoding.TextMarshaler).MarshalText()
 				flagSet.String(tag, string(b), desc)

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/pcelvng/go-config
 
-go 1.12
+go 1.11
 
 require (
+	github.com/hydronica/toml v0.4.0
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/jbsmith7741/go-tools v0.2.0
 	github.com/jbsmith7741/trial v0.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pcelvng/go-config
 go 1.11
 
 require (
+	github.com/davecgh/go-spew v1.1.0
 	github.com/hydronica/toml v0.4.0
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/jbsmith7741/go-tools v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/hydronica/toml v0.4.0 h1:CPo6rmMxHsXdct+XqhhKbYtkBWtvoIRcyfGVUgv6GY8=
+github.com/hydronica/toml v0.4.0/go.mod h1:c7QhbYq3Wp9SlOWuG7MAieKUyXP2P/hXhy/YqWfbS/4=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 h1:ECW73yc9MY7935nNYXUkK7Dz17YuSUI9yqRqYS8aBww=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/jbsmith7741/go-tools v0.2.0 h1:l4jdjoE4y6Mom5P8vhN3eCUs48CR7dAJINNbuhiE/Oo=
@@ -15,3 +17,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- support for yaml, json and toml. 
 - toml supports comments with the 'comment' and 'commented' tags as well as encoding time.duration to a string "1s"
- cleans up help message (-g,-gen)
- adds the show flag