### PR TITLE
fix: load config files by extension (resolves '..yml' loader error)

### DIFF
--- a/config.go
+++ b/config.go
@@ -563,7 +563,10 @@ func (g *GoConfig) parsePath(pth string) (fpth, ext string, err error) {
 		return "", "", nil
 	}
 
-	ext = path.Ext(pth)
+	// path.Ext returns the extension with a leading dot (e.g. ".yml") but
+	// registered loader extensions are stored without it (e.g. "yml"), so
+	// trim the dot to keep extension matching consistent.
+	ext = strings.TrimPrefix(path.Ext(pth), ".")
 	if ext == "" {
 		// maybe pth is just an extension.
 		if g.isValidExt(pth) {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadFromFileExtensions verifies that config files are loaded based on
+// their file extension regardless of the leading dot returned by path.Ext.
+//
+// Regression test for https://github.com/pcelvng/go-config/issues/37 where
+// loading a ".yml"/".yaml"/etc. file failed with:
+//
+//	loader not found for file extension '..yml'
+func TestLoadFromFileExtensions(t *testing.T) {
+	type sub struct {
+		Endpoint string `yaml:"endpoint" toml:"endpoint" json:"endpoint"`
+	}
+	type cfg struct {
+		Name string `yaml:"name" toml:"name" json:"name"`
+		Sub  sub    `yaml:"sub" toml:"sub" json:"sub"`
+	}
+
+	cases := []struct {
+		name     string
+		file     string
+		contents string
+		loader   string
+	}{
+		{
+			name:     "yml",
+			file:     "config.yml",
+			contents: "name: from-yaml\nsub:\n  endpoint: yaml-endpoint\n",
+			loader:   "yaml",
+		},
+		{
+			name:     "yaml",
+			file:     "config.yaml",
+			contents: "name: from-yaml\nsub:\n  endpoint: yaml-endpoint\n",
+			loader:   "yaml",
+		},
+		{
+			name:     "toml",
+			file:     "config.toml",
+			contents: "name = \"from-toml\"\n[sub]\nendpoint = \"toml-endpoint\"\n",
+			loader:   "toml",
+		},
+		{
+			name:     "json",
+			file:     "config.json",
+			contents: `{"name":"from-json","sub":{"endpoint":"json-endpoint"}}`,
+			loader:   "json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			fpath := filepath.Join(dir, tc.file)
+			if err := os.WriteFile(fpath, []byte(tc.contents), 0o600); err != nil {
+				t.Fatalf("writing temp config: %v", err)
+			}
+
+			c := &cfg{}
+			err := New().DisableStdFlags().With(tc.loader).SetConfigPath(fpath).Load(c)
+			if err != nil {
+				t.Fatalf("unexpected error loading %q: %v", tc.file, err)
+			}
+
+			if c.Name == "" {
+				t.Errorf("expected Name to be populated from %q, got empty", tc.file)
+			}
+			if c.Sub.Endpoint == "" {
+				t.Errorf("expected Sub.Endpoint to be populated from %q, got empty", tc.file)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #37, where loading any config file failed with an error like:

```
loader not found for file extension '..yml'
```

### Root cause
`parsePath` derived the extension via `path.Ext(pth)`, which returns the extension **with** a leading dot (e.g. `.yml`). Registered loader extensions, however, are stored **without** the dot (`yml`, `yaml`, `toml`, `json`). As a result:
- `hasRegisteredExt(".yml")` never matched the registered `"yml"`, and
- the `LoaderNotFoundErr` formatter prepends another `.`, producing the doubled `'..yml'` in the message.

This affected every supported file type, so config files could not be loaded by path at all.

### Fix
Trim the leading dot in `parsePath` so the parsed extension is consistent with how extensions are stored and compared everywhere else.

## Test plan
- [x] Added `TestLoadFromFileExtensions`, a regression test that loads `.yml`, `.yaml`, `.toml`, and `.json` files and asserts values (including nested struct values) populate without error.
- [x] Confirmed the new test fails before the fix (`loader not found for file extension '..yml'`) and passes after.
- [x] `go test -race ./...`, `go vet ./...`, and `gofmt -l .` all clean.